### PR TITLE
Fix default `dct_z` in active layers

### DIFF
--- a/ldsim/preprocessing/design.py
+++ b/ldsim/preprocessing/design.py
@@ -43,7 +43,7 @@ class Layer:
         self.dct_z = dict.fromkeys(params, [])
         if active:
             self.dct_x.update(dict.fromkeys(params_active, [np.nan]))
-            self.dct_z.update(dict.fromkeys(params_active, [1.0]))
+            self.dct_z.update(dict.fromkeys(params_active, []))
 
     def __repr__(self):
         s1 = 'Layer \"{}\"'.format(self.name)


### PR DESCRIPTION
Fix error in active region parameters initialization. Previously, when using a 2D model, these parameters' (namely `g0` and `N_tr`) were initialized to have a linear dependency on the z-coordinate with a coefficient `1.0`. I.e., they were of the form:
$$p(z) = p(z=0) + 1.0 \cdot z, \qquad \forall p \in \\{ g_0, N_{tr} \\}.$$
In practice, this did not have any  effect on the simulation results, because for currently used parameters and units $p \gg z$.